### PR TITLE
Add while(!Serial) for reliable Serial init

### DIFF
--- a/software/arduino/libraries/Clyde/Examples/ClydeOriginal/ClydeOriginal.ino
+++ b/software/arduino/libraries/Clyde/Examples/ClydeOriginal/ClydeOriginal.ino
@@ -13,6 +13,7 @@ void setup() {
   Wire.begin();
   
   Serial.begin(9600);
+  while (!Serial) ;
   sCmd.addCommand("SERIAL", cmdSerial);
   sCmd.addCommand("VERSION", cmdVersion);
   sCmd.addCommand("RESET", cmdReset);
@@ -23,6 +24,7 @@ void setup() {
   
   //Clyde.eeprom()->reset();
   Clyde.begin();
+  Serial.println("Clyde is Ready!");
 }
 
 void loop() {

--- a/software/arduino/libraries/Clyde/Examples/ClydeOriginal/ClydeOriginal.ino
+++ b/software/arduino/libraries/Clyde/Examples/ClydeOriginal/ClydeOriginal.ino
@@ -13,7 +13,8 @@ void setup() {
   Wire.begin();
   
   Serial.begin(9600);
-  while (!Serial) ;
+  // Uncomment this line to talk to Clyde over the Serial Monitor
+  // while (!Serial) ;
   sCmd.addCommand("SERIAL", cmdSerial);
   sCmd.addCommand("VERSION", cmdVersion);
   sCmd.addCommand("RESET", cmdReset);


### PR DESCRIPTION
If you don't include `while(!Serial);`, Clyde's serial
port is very very unreliable.  This is due to the fact
that Clyde is based on the Ardunino Leonardo, which shares
USB with serial communication.

Add a Serial output so people know that Clyde is now ready
and willing to accept commands.
